### PR TITLE
Composition API Component Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### 4.2.0 - 2024-04-dd
 
 ### Add
-- Include `emit` function from `setup()` as a third parameter to handle
-  Composition API components.
+- Include `emit` function from `setup()` as an optional createEmitExtendable
+  parameter to handle Composition API components.
 
 ### 4.1.0 - 2022-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vue-extendable-event ChangeLog
 
+### 4.2.0 - 2024-04-dd
+
+### Add
+- Include `emit` function from `setup()` as a third parameter to handle
+  Composition API components.
+
 ### 4.1.0 - 2022-05-26
 
 ### Add

--- a/README.md
+++ b/README.md
@@ -115,3 +115,46 @@ export default {
   }
 }
 ```
+
+
+Example for Vue 3 Composition API which does not have access to `this`:
+
+```js
+<script>
+import {createEmitExtendable} from '@digitalbazaar/vue-extendable-event';
+import {ref} from 'vue';
+
+// Constants
+const emitExtendable = createEmitExtendable();
+
+export default {
+  name: 'MyComponent',
+  props: {
+    bar: {
+      default: 'bar',
+      type: String,
+    }
+  },
+  emits: ['foo'],
+  setup(props, {emit}) {
+    // Refs
+    const loading = ref(false);
+
+    // Helper functions
+    async function click() {
+      loading.value = true;
+      try {
+        const event = {foo: props.bar};
+        await emitExtendable('foo', event, emit);
+      } catch(e) {
+        // handle/display error somehow
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    return {click};
+  }
+};
+</script>
+```

--- a/README.md
+++ b/README.md
@@ -117,15 +117,12 @@ export default {
 ```
 
 
-Example for Vue 3 Composition API which does not have access to `this`:
+Example for Vue 3 Composition API, pass emit into createEmitExtendable:
 
 ```js
 <script>
 import {createEmitExtendable} from '@digitalbazaar/vue-extendable-event';
 import {ref} from 'vue';
-
-// Constants
-const emitExtendable = createEmitExtendable();
 
 export default {
   name: 'MyComponent',
@@ -137,15 +134,16 @@ export default {
   },
   emits: ['foo'],
   setup(props, {emit}) {
-    // Refs
+    // Pass in the emit function to createEmitExtendable
+    const emitExtendable = createEmitExtendable({emit});
+
     const loading = ref(false);
 
-    // Helper functions
     async function click() {
       loading.value = true;
       try {
         const event = {foo: props.bar};
-        await emitExtendable('foo', event, emit);
+        await emitExtendable('foo', event);
       } catch(e) {
         // handle/display error somehow
       } finally {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,17 @@ export default function install(app) {
   app.config.globalProperties.$emitExtendable = emitExtendable;
 }
 
-export function createEmitExtendable() {
+export function createEmitExtendable({emit}) {
+  if(!emit && !getCurrentInstance()) {
+    throw new TypeError('Emit function is not present.');
+  }
+  if(emit) {
+    return emitExtendable.bind({emit});
+  }
   return emitExtendable.bind(getCurrentInstance());
 }
 
-// Pass in the emit function from setup when using a Vue 3 composition api component
-export async function emitExtendable(name, event = {}, emit) {
+export async function emitExtendable(name, event = {}) {
   if(!(event && typeof event === 'object')) {
     throw new TypeError('"event" must be an object.');
   }
@@ -35,7 +40,7 @@ export async function emitExtendable(name, event = {}, emit) {
       }
       response = p;
     }
-  }, emit);
+  });
 
   // await any lifetime extensions
   await Promise.all(promises);
@@ -50,13 +55,7 @@ function _emit(...args) {
   }
   if(this?.emit) {
     return this.emit(...args);
-  } 
-  if(getCurrentInstance()) {
-    const {emit} = getCurrentInstance();
-    return emit(...args);
   }
-  if(typeof args[2] === 'function') {
-    const emit = args[2];
-    return emit(...args.slice(0, 2));
-  }
+  const {emit} = getCurrentInstance();
+  return emit(...args);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,12 @@ export default function install(app) {
 }
 
 export function createEmitExtendable({emit}) {
-  if(!emit && !getCurrentInstance()) {
-    throw new TypeError(
-      '"emit" is required when there is no current component instance.');
-  }
   if(emit) {
     return emitExtendable.bind({emit});
+  }
+  if(!getCurrentInstance()) {
+    throw new TypeError(
+      '"emit" is required when there is no current component instance.');
   }
   return emitExtendable.bind(getCurrentInstance());
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,8 @@ export function createEmitExtendable() {
   return emitExtendable.bind(getCurrentInstance());
 }
 
-export async function emitExtendable(name, event = {}) {
+// Pass in the emit function from setup when using a Vue 3 composition api component
+export async function emitExtendable(name, event = {}, emit) {
   if(!(event && typeof event === 'object')) {
     throw new TypeError('"event" must be an object.');
   }
@@ -34,7 +35,7 @@ export async function emitExtendable(name, event = {}) {
       }
       response = p;
     }
-  });
+  }, emit);
 
   // await any lifetime extensions
   await Promise.all(promises);
@@ -49,7 +50,13 @@ function _emit(...args) {
   }
   if(this?.emit) {
     return this.emit(...args);
+  } 
+  if(getCurrentInstance()) {
+    const {emit} = getCurrentInstance();
+    return emit(...args);
   }
-  const {emit} = getCurrentInstance();
-  return emit(...args);
+  if(typeof args[2] === 'function') {
+    const emit = args[2];
+    return emit(...args.slice(0, 2));
+  }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ export default function install(app) {
 
 export function createEmitExtendable({emit}) {
   if(!emit && !getCurrentInstance()) {
-    throw new TypeError('Emit function is not present.');
+    throw new TypeError(
+      '"emit" is required when there is no current component instance.');
   }
   if(emit) {
     return emitExtendable.bind({emit});


### PR DESCRIPTION
#### _Resolves #5_

Include emit function as optional parameter for Composition API components

---

### What kind of change does this PR introduce?

- Feature extension.

<br/>

### What is the current behavior?

- Composition API components error out when using emitExtendable.

<br/>

### What is the new behavior?

- The function emitExtendable accepts `emit` as an optional parameter.
- README has been updated with a Vue 3 Composition API example.

<br/>

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

- Locally.

<br/>

### Screenshots: n/a